### PR TITLE
ci(github action): apply conventional commits validation to PR commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,3 @@
 <!-- 
 Please describe what this PR do.
  -->
-
-
-## Type of change
-<!--
-Please insert 'x' one of the type of change.
- -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Documentation update
-- [ ] Refactoring, Maintenance
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

--- a/.github/workflows/base-check-commit-message.yml
+++ b/.github/workflows/base-check-commit-message.yml
@@ -16,12 +16,12 @@ jobs:
         uses: tim-actions/get-pr-commits@master
         with:
           token: ${{ secrets.envPAT }}
-      - name: Check Subject Line Length
+      - name: Check Conventional Commit Format
         uses: tim-actions/commit-message-checker-with-regex@v0.3.2
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.{0,50}(\n.*)*$'
-          error: 'Subject too long (max 50)'
+          pattern: '^(feat|fix|docs|style|refactor|test|chore|ci|build|perf)(\(\S+\))?: .+$'
+          error: 'Commit message must follow Conventional Commits format'
       - name: Check Body Line Length
         if: ${{ success() || failure() }}
         uses: tim-actions/commit-message-checker-with-regex@v0.3.2


### PR DESCRIPTION
## Description
ci(github action): apply conventional commits validation to PR commits & delete PR default template